### PR TITLE
Handle different lockfileVersions

### DIFF
--- a/src/packages/lockfiles.ts
+++ b/src/packages/lockfiles.ts
@@ -12,7 +12,10 @@ export function getDependenciesOfLockfile(packages: { [k: string]: VersionOrRang
   const npmLock = {
     path: npmLockPath,
     read() {
-      const { dependencies } = fs.readJsonSync(this.path)
+      const lockfileContent = fs.readJsonSync(this.path)
+      let dependencies = lockfileContent.dependencies
+      if (lockfileContent.lockfileVersion > 1)
+        dependencies = lockfileContent.packages[''].dependencies
       const result: Record<string, VersionOrRange> = {}
       for (const packageName in packages)
         dependencies[packageName] && (result[packageName] = { version: dependencies[packageName].version })

--- a/src/packages/lockfiles.ts
+++ b/src/packages/lockfiles.ts
@@ -14,11 +14,17 @@ export function getDependenciesOfLockfile(packages: { [k: string]: VersionOrRang
     read() {
       const lockfileContent = fs.readJsonSync(this.path)
       let dependencies = lockfileContent.dependencies
-      if (lockfileContent.lockfileVersion > 1)
-        dependencies = lockfileContent.packages[''].dependencies
+      let packageNamePrefix = ''
+      if (lockfileContent.lockfileVersion > 1) {
+        dependencies = lockfileContent.packages
+        packageNamePrefix = 'node_modules/'
+      }
       const result: Record<string, VersionOrRange> = {}
-      for (const packageName in packages)
-        dependencies[packageName] && (result[packageName] = { version: dependencies[packageName].version })
+      for (const packageName in packages) {
+        const dependencyKey = packageNamePrefix + packageName
+        if (dependencies[dependencyKey])
+          result[packageName] = { version: dependencies[dependencyKey].version }
+      }
 
       return result
     },


### PR DESCRIPTION
This pull request includes changes to handle different lockfile versions. This seems to fix #3 :slightly_smiling_face: 

Dependencies are located in another place since version 2: "The root project is typically listed with a key of "", and all other packages are listed with their relative paths from the root project folder." - <https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json>