### PR TITLE
Rework logger

### DIFF
--- a/src/chatgpt.ts
+++ b/src/chatgpt.ts
@@ -1,8 +1,7 @@
 import type { OpenaiOption } from './types'
-import chalk from 'chalk'
 import fetch from 'node-fetch'
 import { getGlobalConfig, openaiBaseURL, openaiModels } from './shared'
-import { log } from './utils/console'
+import { log, warn } from './utils/console'
 import { safeJSON } from './utils/object'
 
 const defaultConfig = {
@@ -40,7 +39,7 @@ export async function recommendDependencies(packageName: string, openaiOptions: 
     }
     catch (e: any) {
       log()
-      log(chalk.yellow(e))
+      warn(e)
       log()
     }
   }

--- a/src/check.ts
+++ b/src/check.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch'
 import semver from 'semver'
 import { recommendDependencies } from './chatgpt'
 import { getGlobalConfig } from './shared'
-import { error, log } from './utils/console'
+import { error, log, ok, warn } from './utils/console'
 import { getRegistry } from './utils/exec'
 import { startSpinner, stopSpinner } from './utils/spinner'
 
@@ -22,8 +22,7 @@ export async function checkDependencies(dependencies: Record<string, VersionOrRa
 
     if (result.deprecated) {
       haveDeprecated = true
-      log(`${chalk.bgYellow(' WARN ')} ${chalk.yellow(`${result.name}@${result.version}: `)}${result.time}`)
-      log(chalk.red(`deprecated: ${result.deprecated}`))
+      warn(`${result.name}@${result.version}: ${result.time}\ndeprecated: ${result.deprecated}`)
 
       if (result.recommend) {
         log(chalk.green('recommended: '))
@@ -39,7 +38,7 @@ export async function checkDependencies(dependencies: Record<string, VersionOrRa
     }
   }
 
-  log(chalk.green(`All dependencies retrieved successfully.${haveDeprecated ? '' : ' There are no deprecated dependencies.'}`))
+  ok(`All dependencies retrieved successfully.${haveDeprecated ? '' : ' There are no deprecated dependencies.'}`)
 }
 
 const globalConfig = getGlobalConfig()

--- a/src/io/config.ts
+++ b/src/io/config.ts
@@ -1,9 +1,9 @@
-/* eslint-disable no-console */
 import type { ConfigOption } from '../types'
 import process from 'node:process'
 import fs from 'fs-extra'
 import { version } from '../../package.json'
 import { openaiModels, rcPath } from '../shared'
+import { error, log } from '../utils/console'
 import { get, set, unset } from '../utils/object'
 
 export default function configure(options: ConfigOption) {
@@ -18,14 +18,14 @@ export default function configure(options: ConfigOption) {
 
   if (options.get) {
     const value = get(config, options.get)
-    console.log(value)
+    log(value)
   }
 
   if (options.set) {
     const [path, value] = options.set
 
     if (path === 'openaiModel' && !openaiModels.includes(value)) {
-      console.error(`error: option '--openaiModel <value>' argument '${value}' is invalid. Allowed choices are ${openaiModels.join(', ')}.`)
+      error(`error: option '--openaiModel <value>' argument '${value}' is invalid. Allowed choices are ${openaiModels.join(', ')}.`)
       process.exit(1)
     }
 
@@ -50,5 +50,5 @@ export default function configure(options: ConfigOption) {
   }
 
   if (options.list)
-    console.log(JSON.stringify(config, null, 2))
+    log(JSON.stringify(config, null, 2))
 }

--- a/src/io/current.ts
+++ b/src/io/current.ts
@@ -3,6 +3,7 @@ import { checkDependencies } from '../check'
 import { isGitPackage, isLocalPackage, isURLPackage } from '../filter'
 import { getDependenciesOfLockfile } from '../packages/lockfiles'
 import { getDependenciesOfPackageJson } from '../packages/package_json'
+import { error } from '../utils/console'
 
 export default async function checkCurrent(options: CommonOption) {
   try {
@@ -23,6 +24,6 @@ export default async function checkCurrent(options: CommonOption) {
     checkDependencies(dependencies, options)
   }
   catch (e: any) {
-    console.error(e.message)
+    error(e.message)
   }
 }

--- a/src/io/global.ts
+++ b/src/io/global.ts
@@ -1,5 +1,6 @@
 import type { GlobalOption } from '../types'
 import { checkDependencies } from '../check'
+import { error } from '../utils/console'
 import { execCommand } from '../utils/exec'
 
 const yarnRegexp = /info "(.+)" has binaries/g
@@ -32,6 +33,6 @@ export default function checkGlobal(options: GlobalOption) {
     checkDependencies(dependencies, openaiOptions)
   }
   catch (e: any) {
-    console.error(e.message)
+    error(e.message)
   }
 }

--- a/src/io/node.ts
+++ b/src/io/node.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { createRequire } from 'node:module'
 import process from 'node:process'
-import chalk from 'chalk'
 import { coerce, gt, major } from 'semver'
 import { ok, warn } from '../utils/console'
 

--- a/src/io/node.ts
+++ b/src/io/node.ts
@@ -1,8 +1,7 @@
-/* eslint-disable no-console */
 import process from 'node:process'
-import chalk from 'chalk'
 import nodeReleases from 'node-releases/data/release-schedule/release-schedule.json'
 import { coerce, gt, major } from 'semver'
+import { ok, warn } from '../utils/console'
 
 function getLatestNodeVersion() {
   const versions = Object.keys(nodeReleases)
@@ -23,17 +22,17 @@ function checkNode() {
     const currentDate = new Date()
     const isNodeVersionSupported = currentDate < endDate
     if (isNodeVersionSupported) {
-      console.log(chalk.green(`Your node version (${nodeVersion}) is supported until ${nodeVersionData.end}.`))
+      ok(`Your node version (${nodeVersion}) is supported until ${nodeVersionData.end}.`)
     }
     else {
-      console.log(chalk.yellow(`Your node version (${nodeVersion}) is no longer supported since ${nodeVersionData.end}.`))
+      warn(`Your node version (${nodeVersion}) is no longer supported since ${nodeVersionData.end}.`)
     }
   }
   else if (gt(nodeVersion, latestNodeVersion)) {
-    console.log(chalk.yellow(`Your node version (${nodeVersion}) is higher than the latest version ${latestNodeVersion}. Please update 'npm-deprecated-check'.`))
+    warn(`Your node version (${nodeVersion}) is higher than the latest version ${latestNodeVersion}. Please update 'npm-deprecated-check'.`)
   }
   else {
-    console.log(chalk.yellow(`Your node version (${nodeVersion}) can't be found in the release schedule. Please update 'npm-deprecated-check'.`))
+    warn(`Your node version (${nodeVersion}) can't be found in the release schedule. Please update 'npm-deprecated-check'.`)
   }
 }
 

--- a/src/packages/package_json.ts
+++ b/src/packages/package_json.ts
@@ -1,12 +1,13 @@
 import { resolve } from 'node:path'
 import fs from 'fs-extra'
+import { error } from '../utils/console'
 import { formatDependencies } from '../utils/format'
 
 const packageJsonPath = resolve('./package.json')
 
 export function getDependenciesOfPackageJson() {
   if (!fs.existsSync(packageJsonPath))
-    return console.error('package.json does not exist in the current path, please execute it under the correct project path.')
+    return error('package.json does not exist in the current path, please execute it under the correct project path.')
 
   const { dependencies, devDependencies } = fs.readJsonSync(packageJsonPath)
 

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -1,12 +1,18 @@
 /* eslint-disable no-console */
-import { stopSpinner } from './spinner'
+import chalk from 'chalk'
 
 export function error(text?: string) {
-  stopSpinner()
-  console.error(text ?? '')
+  console.error(`${chalk.bgRed(' ERROR ')} ${chalk.red(text ?? '')}`)
 }
 
 export function log(text?: string) {
-  stopSpinner()
   console.log(text ?? '')
+}
+
+export function ok(text?: string) {
+  console.log(`${chalk.bgGreen('  OK  ')}  ${text ?? ''}`)
+}
+
+export function warn(text?: string) {
+  console.log(`${chalk.bgYellowBright(' WARN ')} ${chalk.yellow(text ?? '')}`)
 }

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -10,7 +10,7 @@ export function log(text?: string) {
 }
 
 export function ok(text?: string) {
-  console.log(`${chalk.bgGreen('  OK  ')}  ${text ?? ''}`)
+  console.log(`${chalk.bgGreen('  OK  ')} ${text ?? ''}`)
 }
 
 export function warn(text?: string) {


### PR DESCRIPTION
My idea was to adapt the log output a little to that of pnpm (like you already did for the warn messages).

What do you think? :slightly_smiling_face: 

## `npm run dev current`
### before
![Screenshot from 2024-10-28 17-00-00](https://github.com/user-attachments/assets/15f1fd8c-77f7-41e5-8686-0db1a0c64b5a)
### after
![Screenshot from 2024-10-28 16-56-01](https://github.com/user-attachments/assets/1f977088-94a3-4e2a-b59d-74bfbf31b8fd)

## `npm run dev package request`
### before
![Screenshot from 2024-10-28 17-07-52](https://github.com/user-attachments/assets/0dd82668-ed6d-4926-b88d-6e3cdd4e86fd)
### after
![Screenshot from 2024-10-28 17-36-17](https://github.com/user-attachments/assets/1da9bc44-3a64-4473-966d-64ab2b58a32d)


## `npm run dev package not-existing-package`
### before
![Screenshot from 2024-10-28 17-28-28](https://github.com/user-attachments/assets/0153e2cc-7edd-476e-82fc-b8ad2359adc1)
### after
![Screenshot from 2024-10-28 17-25-55](https://github.com/user-attachments/assets/f7171833-15f5-47df-82cf-e8168d025aec)
