### PR TITLE
Run tests also with node 18

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -31,10 +31,10 @@ jobs:
           check-latest: true
           cache: npm
 
-      - name: Install dependencies
+      - name: Install pnpm
         run: npm install -g pnpm
 
-      - name: Install pnpm
+      - name: Install dependencies
         run: pnpm --silent install
 
       - name: Check linting

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [22.x, 20.x]
+        node-version: [22, 20, 18]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Our tests do not work with node 16 because the built-in test-runner is not mature enough in this version.

In version 18, the test-runner is still in experimental state, but our tests work :slightly_smiling_face: 