### PR TITLE
ci: update node version matrix to include Node.js 24

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [22, 20, 18]
+        node-version: [24, 22, 20, 18]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The tests fail, so I mark the PR as a draft.