### PR TITLE
chore: remove `.npmrc` configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-workspace-root-check=true


### PR DESCRIPTION
Since we don't have `workspaces` in `package.json`, this file (with that content) is not necessary.