### PR TITLE
feat: add compat command for Node.js version compatibility checking

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [24, 22]
+        node-version: [26, 24, 22]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm install -g npm-deprecated-check
 - Check if the current environment meets the Node.js version range required for dependency operation.
 - Calculate the minimum Node.js version required across all dependencies.
 - Suggest compatible dependency versions when Node.js version requirements are not met.
+- Check Node.js version compatibility for a project or package when upgrading or downgrading Node.js.
 - MCP Server support: expose tools for external AI agents to consume deprecation data.
 
 ## Node.js Version Compatibility
@@ -86,6 +87,7 @@ Commands:
   current [options]                check the packages of the current project
   global [options]                 check global packages, default: npm
   package [options] <packageName>  check for specified package
+  compat [options] [packageName]   check Node.js version compatibility for project or package
   node                             check if used node version is deprecated (reached End Of Life)
   config [options]                 inspect and modify the config
   help [command]                   display help for command
@@ -118,6 +120,46 @@ For `package`:
 Options:
   -r, --range <value>       check specified versions
   --registry <value>        specify registry URL, default: https://registry.npmjs.org/
+```
+
+For `compat`:
+
+```bash
+Usage: ndc compat [packageName] [options]
+
+check Node.js version compatibility for project or package
+
+Options:
+  --node <version>          target Node.js version (e.g. "18", "20.11.0"), default: current Node version
+  --deep                    deep inspection for monorepo projects (project mode only)
+  --ignore <value>          ignore specific packages, example: request,tslint
+  --registry <value>        specify registry URL, default: https://registry.npmjs.org/
+```
+
+### Compat Examples
+
+Check current project against the current Node version:
+
+```bash
+ndc compat
+```
+
+Check current project against a target Node version:
+
+```bash
+ndc compat --node 18
+```
+
+Check a specific package against a target Node version:
+
+```bash
+ndc compat esbuild --node 18
+```
+
+Deep check monorepo projects:
+
+```bash
+ndc compat --node 20 --deep
 ```
 
 You can also save options to global configuration:
@@ -167,6 +209,7 @@ npx npm-deprecated-check --mcp
 | `check_current_project` | Check all dependencies of the current project |
 | `check_global` | Check globally installed packages |
 | `check_node` | Check if the current Node.js version has reached EOL |
+| `check_compat` | Check Node.js version compatibility for a project or package |
 
 All tools return structured JSON data. The AI agent can use this data to provide recommendations, suggest alternatives, or generate reports.
 
@@ -188,6 +231,14 @@ All tools return structured JSON data. The AI agent can use this data to provide
 - `registry` (optional) — custom npm registry URL
 
 **check_node:** No parameters.
+
+**check_compat:**
+- `packageName` (optional) — npm package name. If not provided, checks the current project
+- `nodeVersion` (optional) — target Node.js version (e.g. `"18"`, `"20.11.0"`). Defaults to current Node version
+- `projectPath` (optional) — absolute path to project root (only used when `packageName` is not provided)
+- `deep` (optional) — deep inspection for monorepo projects
+- `ignore` (optional) — comma-separated package names to ignore
+- `registry` (optional) — custom npm registry URL
 
 ## Credits
 

--- a/docs/superpowers/plans/2026-05-24-compat-command.md
+++ b/docs/superpowers/plans/2026-05-24-compat-command.md
@@ -1,0 +1,781 @@
+# `compat` Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `compat` command that checks Node.js version compatibility for a project or package based on `engines.node`, supporting a target Node version parameter.
+
+**Architecture:** Parameterize the existing `checkDependencies` function in `check.ts` to accept an optional `targetNodeVersion`, then create a new `io/compat.ts` entry point that reuses the dependency collection logic from `current.ts`. Add a dedicated render function and an MCP tool.
+
+**Tech Stack:** TypeScript, Commander.js, semver, @modelcontextprotocol/sdk, zod
+
+---
+
+### Task 1: Add `CompatOption` type to `types.ts`
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Add `CompatOption` interface**
+
+Add the following interface after the existing `PackageOption` interface in `src/types.ts`:
+
+```typescript
+export interface CompatOption extends CommonOption {
+  packageName?: string
+  node?: string
+  deep: boolean
+  ignore: string
+}
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(compat): add CompatOption type"
+```
+
+---
+
+### Task 2: Parameterize `checkDependencies` in `check.ts`
+
+**Files:**
+- Modify: `src/check.ts`
+
+- [ ] **Step 1: Add `targetNodeVersion` to `checkDependencies` options**
+
+In `src/check.ts`, update the `checkDependencies` function signature. Add `targetNodeVersion?: string` to the options parameter:
+
+```typescript
+export async function checkDependencies(
+  dependencies: Record<string, VersionOrRange>,
+  config: CommonOption,
+  options?: {
+    dependencyTypes?: Record<string, 'production' | 'development'>
+    projectEnginesNode?: string
+    silent?: boolean
+    targetNodeVersion?: string
+  },
+): Promise<CheckResult> {
+```
+
+Then pass `targetNodeVersion` to `getPackageInfo`:
+
+```typescript
+const result = await getPackageInfo(packageName, dependencies[packageName], config, options?.targetNodeVersion)
+```
+
+- [ ] **Step 2: Update `getPackageInfo` to accept `targetNodeVersion`**
+
+Change the function signature:
+
+```typescript
+async function getPackageInfo(packageName: string, versionOrRange: VersionOrRange, config: CommonOption, targetNodeVersion?: string): Promise<PackageInfo> {
+```
+
+Replace the usage of `currentNode` inside `getPackageInfo` with a local variable:
+
+```typescript
+const effectiveNode = coerce(targetNodeVersion) || currentNode
+```
+
+Then use `effectiveNode` instead of `currentNode` in the `satisfies` check and pass it to `findCompatibleVersion`:
+
+```typescript
+if (requiredNode) {
+  if (satisfies(effectiveNode, requiredNode)) {
+    requiredNode = undefined
+  }
+  else {
+    compatibleVersion = findCompatibleVersion(packageRes, versionOrRange, effectiveNode)
+  }
+}
+```
+
+- [ ] **Step 3: Update `findCompatibleVersion` — no signature change needed**
+
+`findCompatibleVersion` already accepts a `SemVer` parameter (`currentNode`). Since we now pass `effectiveNode` (which is also a `SemVer` from `coerce`), no changes are needed to this function.
+
+- [ ] **Step 4: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/check.ts
+git commit -m "feat(compat): parameterize checkDependencies with targetNodeVersion"
+```
+
+---
+
+### Task 3: Create `src/io/compat.ts`
+
+**Files:**
+- Create: `src/io/compat.ts`
+
+- [ ] **Step 1: Write the `checkCompat` function**
+
+Create `src/io/compat.ts` with the following content:
+
+```typescript
+import type { CompatOption, VersionOrRange } from '../types'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { coerce } from 'semver'
+import { checkDependencies } from '../check'
+import { isGitPackage, isLocalPackage, isURLPackage } from '../filter'
+import { getDependenciesOfLockfile } from '../packages/lockfiles'
+import { getDependenciesOfPackageJson } from '../packages/package_json'
+import { renderCompatResult } from '../render'
+import { error, log, warn } from '../utils/console'
+
+export default async function checkCompat(options: CompatOption) {
+  const targetNodeVersion = options.node || process.version
+  const effectiveNode = coerce(targetNodeVersion)
+  if (!effectiveNode) {
+    warn(`Invalid Node version: "${targetNodeVersion}", falling back to current Node version (${process.version})`)
+  }
+
+  if (options.packageName) {
+    await checkPackageCompat(options, targetNodeVersion)
+  }
+  else {
+    await checkProjectCompat(options, targetNodeVersion)
+  }
+}
+
+async function checkPackageCompat(options: CompatOption, targetNodeVersion: string) {
+  const { packageName, node, ...restOptions } = options
+  const checkOptions = { ...restOptions, failfast: false }
+
+  const result = await checkDependencies(
+    { [packageName!]: { range: undefined } },
+    checkOptions,
+    { silent: false, targetNodeVersion },
+  )
+
+  renderCompatResult(result, {
+    targetNodeVersion,
+    packageName: packageName!,
+  })
+}
+
+async function checkProjectCompat(options: CompatOption, targetNodeVersion: string) {
+  const currentPath = process.cwd()
+  const pkgPaths = options.deep ? findPackageJsonDirs(currentPath) : [currentPath]
+
+  for (const pkgPath of pkgPaths) {
+    if (options.deep) {
+      log(`> ${pkgPath}`)
+    }
+    const result = await checkProjectPackageJson(pkgPath, options, targetNodeVersion)
+    log()
+  }
+}
+
+function findPackageJsonDirs(dir: string, results: Array<string> = []) {
+  const pkgPath = join(dir, 'package.json')
+  if (existsSync(pkgPath)) {
+    results.push(dir)
+  }
+
+  let files
+  try {
+    files = readdirSync(dir)
+  }
+  catch {
+    return results
+  }
+
+  for (const file of files) {
+    if (file === 'node_modules') {
+      continue
+    }
+    const dirPath = join(dir, file)
+    try {
+      const stat = statSync(dirPath)
+      if (stat.isDirectory()) {
+        findPackageJsonDirs(dirPath, results)
+      }
+    }
+    catch {
+    }
+  }
+
+  return results
+}
+
+async function checkProjectPackageJson(pkgPath: string, options: CompatOption, targetNodeVersion: string) {
+  const packageJsonPath = join(pkgPath, 'package.json')
+  const dependenciesOfPackageJson = getDependenciesOfPackageJson(packageJsonPath)
+
+  if (!dependenciesOfPackageJson)
+    return
+
+  try {
+    const ignores = options.ignore?.split(',') || []
+
+    const npmDependencies: Record<string, VersionOrRange> = {}
+    const dependencyTypes: Record<string, 'production' | 'development'> = {}
+
+    for (const name in dependenciesOfPackageJson.dependencies) {
+      const versionInfo = dependenciesOfPackageJson.dependencies[name]
+      if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+        npmDependencies[name] = versionInfo
+        dependencyTypes[name] = 'production'
+      }
+    }
+
+    for (const name in dependenciesOfPackageJson.devDependencies) {
+      const versionInfo = dependenciesOfPackageJson.devDependencies[name]
+      if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+        npmDependencies[name] = versionInfo
+        dependencyTypes[name] = 'development'
+      }
+    }
+
+    const dependenciesOfLockfile = await getDependenciesOfLockfile(npmDependencies)
+    const dependencies = Object.assign(npmDependencies, dependenciesOfLockfile)
+
+    const result = await checkDependencies(dependencies, { registry: options.registry, failfast: false }, {
+      dependencyTypes,
+      targetNodeVersion,
+    })
+    renderCompatResult(result, { targetNodeVersion })
+    return result
+  }
+  catch (e: any) {
+    error(e.message)
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: Errors about `renderCompatResult` not existing (will be fixed in Task 4)
+
+Note: This is expected. We'll fix it in the next task. For now, just verify the rest of the file compiles correctly by temporarily commenting out the `renderCompatResult` import and calls if needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/io/compat.ts
+git commit -m "feat(compat): add io/compat.ts with project and package mode"
+```
+
+---
+
+### Task 4: Add `renderCompatResult` to `render.ts`
+
+**Files:**
+- Modify: `src/render.ts`
+
+- [ ] **Step 1: Add the `renderCompatResult` function**
+
+Add the following function to `src/render.ts`. It follows the same output conventions as `renderCheckResult` (using `warn`, `log`, `ok`, `error` from `../utils/console` and `ansis` for coloring). It does NOT output deprecation information — only Node version compatibility.
+
+```typescript
+export function renderCompatResult(
+  result: CheckResult,
+  options?: {
+    targetNodeVersion?: string
+    packageName?: string
+    hasNodeFlag?: boolean
+  },
+) {
+  const { packages, hasErrors, nodeVersionSummary } = result
+  const targetNode = options?.targetNodeVersion || process.version
+  const targetNodeClean = coerce(targetNode)?.version || targetNode
+
+  if (options?.packageName) {
+    const pkg = packages[0]
+    if (pkg?.error) {
+      error(pkg.error)
+      return
+    }
+    warn(`${pkg!.name}@${pkg!.version}: ${pkg!.time}`)
+    if (pkg!.nodeRequirement) {
+      if (!pkg!.requiredNode) {
+        log(`${ansis.cyanBright('Compatible with Node ')}${ansis.magenta(targetNode)}${ansis.cyanBright(' (engines.node: ')}${ansis.magenta(pkg!.nodeRequirement)}${ansis.cyanBright(')')}`)
+      }
+      else {
+        log(`${ansis.magentaBright('Required node: ')}${pkg!.requiredNode}`)
+        if (pkg!.compatibleVersion) {
+          log(`${ansis.cyanBright(`Compatible version for Node ${targetNodeClean}: `)}${ansis.magenta(pkg!.compatibleVersion)}`)
+        }
+      }
+    }
+    else {
+      log(`${ansis.cyanBright('Compatible with Node ')}${ansis.magenta(targetNode)}${ansis.cyanBright(' (no engines.node constraint)')}`)
+    }
+    log()
+    return
+  }
+
+  for (const pkg of packages) {
+    if (pkg.error) {
+      error(pkg.error)
+      log()
+    }
+
+    if (pkg.requiredNode) {
+      warn(`${pkg.name}@${pkg.version}: ${pkg.time}`)
+      log(`${ansis.magentaBright('Required node: ')}${pkg.requiredNode}`)
+      if (pkg.compatibleVersion) {
+        log(`${ansis.cyanBright(`Compatible version for Node ${targetNodeClean}: `)}${ansis.magenta(pkg.compatibleVersion)}`)
+      }
+      log()
+    }
+  }
+
+  const incompatibleCount = packages.filter(p => p.requiredNode).length
+  const errorCount = packages.filter(p => p.error).length
+
+  if (!hasErrors && incompatibleCount === 0) {
+    ok(`All dependencies are compatible with Node ${targetNode}.`)
+  }
+
+  if (nodeVersionSummary) {
+    const { minimumRequired } = nodeVersionSummary
+    const productionMin = minimumRequired.production || minimumRequired.development
+
+    log()
+
+    if (productionMin) {
+      log(ansis.cyanBright('📊 Node Version Summary:'))
+      log(`Minimum engines.node: ${ansis.magenta(`>=${productionMin}`)}`)
+      log(`Target Node version: ${ansis.magenta(targetNode)}`)
+
+      const targetNodeSemver = coerce(targetNode)
+      if (targetNodeSemver && !satisfies(targetNodeSemver, `>=${productionMin}`)) {
+        warn(`Target Node version is below the minimum requirement!`)
+      }
+    }
+  }
+}
+```
+
+Also update the import at the top of `render.ts` to include `PackageInfo` if needed (check if already imported). Actually, since we removed the `PackageInfo[]` arrays and use inline filtering, no additional import is needed beyond what's already there.
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/render.ts
+git commit -m "feat(compat): add renderCompatResult function"
+```
+
+---
+
+### Task 5: Register `compat` command in `cli.ts`
+
+**Files:**
+- Modify: `src/cli.ts`
+
+- [ ] **Step 1: Add import for `checkCompat`**
+
+Add the import at the top of `src/cli.ts`:
+
+```typescript
+import checkCompat from './io/compat'
+```
+
+- [ ] **Step 2: Add `CompatOption` to the type import**
+
+Update the type import line:
+
+```typescript
+import type { CommonOption, CompatOption, ConfigOption, CurrentOption, GlobalOption, PackageOption } from './types'
+```
+
+- [ ] **Step 3: Register the `compat` command**
+
+Add the following command registration after the `package` command and before the `config` command:
+
+```typescript
+program
+  .command('compat [packageName]')
+  .description('check Node.js version compatibility for project or package')
+  .addOption(new Option('--node <version>', 'target Node.js version'))
+  .addOption(new Option('--deep', 'deep inspection for monorepo projects'))
+  .addOption(new Option('--ignore <value>', 'ignore specific packages'))
+  .addOption(registryOption)
+  .action((packageName?: string, option: any) => {
+    const compatOption: CompatOption = {
+      ...option,
+      packageName,
+    }
+    checkCompat(compatOption)
+  })
+```
+
+- [ ] **Step 4: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(compat): register compat command in CLI"
+```
+
+---
+
+### Task 6: Add `check_compat` MCP tool to `mcp.ts`
+
+**Files:**
+- Modify: `src/mcp.ts`
+
+- [ ] **Step 1: Add the `check_compat` MCP tool**
+
+Add the following tool registration in `src/mcp.ts`, after the existing `check_node` tool and before the `const transport = new StdioServerTransport()` line:
+
+```typescript
+server.tool(
+  'check_compat',
+  'Check Node.js version compatibility for a project or package. Reports which dependencies are compatible/incompatible with a target Node version based on engines.node.',
+  {
+    packageName: z.string().optional().describe('npm package name. If not provided, checks the current project.'),
+    nodeVersion: z.string().optional().describe('Target Node.js version (e.g. "18", "20.11.0"). Defaults to current Node version.'),
+    projectPath: z.string().optional().describe('Absolute path to project root (only used when packageName is not provided)'),
+    deep: z.boolean().optional().describe('Deep inspection for monorepo projects'),
+    ignore: z.string().optional().describe('Comma-separated package names to ignore'),
+    registry: z.string().optional().describe('Custom npm registry URL'),
+  },
+  async ({ packageName, nodeVersion, projectPath, deep, ignore, registry }) => {
+    const regResult = validateRegistry(registry || '')
+    if (regResult instanceof Error)
+      return errorResult(regResult.message)
+
+    if (packageName) {
+      const nameResult = validatePackageName(packageName)
+      if (nameResult instanceof Error)
+        return errorResult(nameResult.message)
+
+      try {
+        const targetNodeVersion = nodeVersion || process.version
+        const result = await withTimeout(
+          checkDependencies(
+            { [nameResult]: { range: undefined } },
+            { registry: regResult, failfast: false },
+            { silent: true, targetNodeVersion },
+          ),
+          SECURITY.FETCH_TIMEOUT_MS,
+        )
+
+        const pkg = result.packages[0]
+        if (pkg?.error) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: sanitizeError(pkg.error) }, null, 2) }],
+          }
+        }
+
+        const compatResult = {
+          targetNodeVersion,
+          packages: result.packages.map(p => ({
+            name: p.name,
+            version: p.version,
+            compatible: !p.requiredNode,
+            nodeRequirement: p.nodeRequirement || null,
+            compatibleVersion: p.compatibleVersion || null,
+          })),
+          summary: {
+            total: result.summary.total,
+            incompatible: result.packages.filter(p => p.requiredNode).length,
+            errors: result.summary.errors,
+          },
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(compatResult, null, 2) }],
+        }
+      }
+      catch (e) {
+        return errorResult(sanitizeError(e))
+      }
+    }
+    else {
+      try {
+        const { existsSync, readdirSync, readFileSync, statSync } = await import('node:fs')
+        const { join, isAbsolute } = await import('node:path')
+        const { isGitPackage, isLocalPackage, isURLPackage } = await import('./filter')
+        const { getDependenciesOfLockfile } = await import('./packages/lockfiles')
+        const { getDependenciesOfPackageJson } = await import('./packages/package_json')
+
+        const currentPath = projectPath || process.cwd()
+        if (projectPath && !isAbsolute(projectPath))
+          return errorResult('projectPath must be an absolute path')
+        if (!existsSync(currentPath))
+          return errorResult(`Project path does not exist: ${currentPath}`)
+        if (!existsSync(join(currentPath, 'package.json')))
+          return errorResult(`No package.json found in: ${currentPath}`)
+
+        function findPackageJsonDirs(dir: string, results: Array<string> = [], maxDepth: number = SECURITY.MAX_RECURSION_DEPTH, currentDepth: number = 0) {
+          if (currentDepth >= maxDepth)
+            return results
+          const pkgPath = join(dir, 'package.json')
+          if (existsSync(pkgPath))
+            results.push(dir)
+          let files
+          try {
+            files = readdirSync(dir)
+          }
+          catch {
+            return results
+          }
+          for (const file of files) {
+            if (file === 'node_modules')
+              continue
+            const dirPath = join(dir, file)
+            try {
+              const stat = statSync(dirPath)
+              if (stat.isDirectory())
+                findPackageJsonDirs(dirPath, results, maxDepth, currentDepth + 1)
+            }
+            catch {}
+          }
+          return results
+        }
+
+        const targetNodeVersion = nodeVersion || process.version
+        const pkgPaths = deep ? findPackageJsonDirs(currentPath, [], SECURITY.MAX_RECURSION_DEPTH, 0) : [currentPath]
+        const allDependencies: Record<string, VersionOrRange> = {}
+        const allDependencyTypes: Record<string, 'production' | 'development'> = {}
+
+        for (const pkgPath of pkgPaths) {
+          const packageJsonPath = join(pkgPath, 'package.json')
+          const dependenciesOfPackageJson = getDependenciesOfPackageJson(packageJsonPath)
+          if (!dependenciesOfPackageJson)
+            continue
+
+          const ignores = ignore?.split(',') || []
+          const npmDependencies: Record<string, VersionOrRange> = {}
+          const dependencyTypes: Record<string, 'production' | 'development'> = {}
+
+          for (const name in dependenciesOfPackageJson.dependencies) {
+            const versionInfo = dependenciesOfPackageJson.dependencies[name]
+            if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+              npmDependencies[name] = versionInfo
+              dependencyTypes[name] = 'production'
+            }
+          }
+
+          for (const name in dependenciesOfPackageJson.devDependencies) {
+            const versionInfo = dependenciesOfPackageJson.devDependencies[name]
+            if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+              npmDependencies[name] = versionInfo
+              dependencyTypes[name] = 'development'
+            }
+          }
+
+          const dependenciesOfLockfile = await getDependenciesOfLockfile(npmDependencies)
+          Object.assign(allDependencies, npmDependencies, dependenciesOfLockfile)
+          Object.assign(allDependencyTypes, dependencyTypes)
+        }
+
+        const limitResult = withPackageLimit(allDependencies)
+        if (limitResult instanceof Error)
+          return errorResult(limitResult.message)
+
+        const config = { registry: regResult, failfast: false }
+        const result = await withTimeout(
+          checkDependencies(limitResult, config, {
+            dependencyTypes: allDependencyTypes,
+            targetNodeVersion,
+            silent: true,
+          }),
+          SECURITY.FETCH_TIMEOUT_MS,
+        )
+
+        const compatResult = {
+          targetNodeVersion,
+          packages: result.packages.map(p => ({
+            name: p.name,
+            version: p.version,
+            dependencyType: p.dependencyType || null,
+            compatible: !p.requiredNode,
+            nodeRequirement: p.nodeRequirement || null,
+            compatibleVersion: p.compatibleVersion || null,
+          })),
+          summary: {
+            total: result.summary.total,
+            incompatible: result.packages.filter(p => p.requiredNode).length,
+            errors: result.summary.errors,
+          },
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(compatResult, null, 2) }],
+        }
+      }
+      catch (e) {
+        return errorResult(sanitizeError(e))
+      }
+    }
+  },
+)
+```
+
+- [ ] **Step 2: Run typecheck to verify**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mcp.ts
+git commit -m "feat(compat): add check_compat MCP tool"
+```
+
+---
+
+### Task 7: Build and smoke test
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Build the project**
+
+Run: `pnpm run build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 2: Test `compat` command help**
+
+Run: `node dist/cli.mjs compat --help`
+Expected: Shows help text with `--node`, `--deep`, `--ignore`, `--registry` options
+
+- [ ] **Step 3: Test `compat` project mode (current Node)**
+
+Run: `node dist/cli.mjs compat`
+Expected: Shows compatibility report for current project dependencies
+
+- [ ] **Step 4: Test `compat` project mode (target Node)**
+
+Run: `node dist/cli.mjs compat --node 18`
+Expected: Shows compatibility report for Node 18
+
+- [ ] **Step 5: Test `compat` package mode (current Node)**
+
+Run: `node dist/cli.mjs compat eslint`
+Expected: Shows eslint compatibility with current Node version
+
+- [ ] **Step 6: Test `compat` package mode (target Node)**
+
+Run: `node dist/cli.mjs compat esbuild --node 18`
+Expected: Shows esbuild compatibility with Node 18
+
+- [ ] **Step 7: Run existing tests to verify no regression**
+
+Run: `node --test`
+Expected: All existing tests pass
+
+- [ ] **Step 8: Run lint**
+
+Run: `pnpm run lint`
+Expected: No lint errors
+
+- [ ] **Step 9: Commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix(compat): address build/lint issues"
+```
+
+---
+
+### Task 8: Add tests for `compat` command
+
+**Files:**
+- Create: `test/compat.spec.js`
+
+- [ ] **Step 1: Write tests for the `compat` command**
+
+Create `test/compat.spec.js`:
+
+```javascript
+import assert from 'node:assert/strict'
+import { exec } from 'node:child_process'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const cli = path.resolve(__dirname, '../dist/cli.mjs')
+
+test('compat help', async (t) => {
+  await t.test('shows compat command help', (_t, done) => {
+    exec(`node ${cli} compat --help`, (_error, stdout, _stderr) => {
+      assert.ok(/--node/.test(stdout), 'Expected "--node" option in help.')
+      assert.ok(/--deep/.test(stdout), 'Expected "--deep" option in help.')
+      assert.ok(/--ignore/.test(stdout), 'Expected "--ignore" option in help.')
+      done()
+    })
+  })
+})
+
+test('compat package mode', async (t) => {
+  await t.test('check package compatibility with current Node', (_t, done) => {
+    exec(`node ${cli} compat eslint`, { timeout: 30000 }, (_error, stdout, _stderr) => {
+      assert.ok(/eslint@/.test(stdout), 'Expected eslint version in output.')
+      done()
+    })
+  })
+
+  await t.test('check package compatibility with target Node version', (_t, done) => {
+    exec(`node ${cli} compat esbuild --node 18`, { timeout: 30000 }, (_error, stdout, _stderr) => {
+      assert.ok(/Node 18\./.test(stdout) || /Node v18/.test(stdout), 'Expected Node 18 in output.')
+      done()
+    })
+  })
+})
+
+test('compat project mode', async (t) => {
+  await t.test('check project compatibility with current Node', (_t, done) => {
+    exec(`node ${cli} compat`, { timeout: 60000 }, (_error, stdout, _stderr) => {
+      assert.ok(/compatible/.test(stdout) || /Required node/.test(stdout) || /Node Version Summary/.test(stdout), 'Expected compatibility output.')
+      done()
+    })
+  })
+
+  await t.test('check project compatibility with target Node version', (_t, done) => {
+    exec(`node ${cli} compat --node 18`, { timeout: 60000 }, (_error, stdout, _stderr) => {
+      assert.ok(/Node v?18/.test(stdout), 'Expected Node 18 in output.')
+      done()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Build and run tests**
+
+Run: `pnpm run build && node --test test/compat.spec.js`
+Expected: All tests pass
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `node --test`
+Expected: All tests pass (including existing ones)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/compat.spec.js
+git commit -m "test(compat): add compat command tests"
+```

--- a/docs/superpowers/specs/2026-05-24-compat-command-design.md
+++ b/docs/superpowers/specs/2026-05-24-compat-command-design.md
@@ -1,0 +1,220 @@
+# `compat` Command Design
+
+## Overview
+
+Add a new `compat` command to `npm-deprecated-check` that queries Node.js version compatibility for a project or a specific package based on `engines.node`. This helps users determine whether their dependencies are compatible when upgrading or downgrading to a target Node version.
+
+## CLI Interface
+
+```
+ndc compat [--node <version>] [packageName] [--deep] [--ignore <value>] [--registry <value>]
+```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `[packageName]` | Optional package name. If omitted, checks the current project. | — |
+| `--node <version>` | Target Node.js version (e.g. `18`, `20.11.0`). If omitted, uses the current Node version (`process.version`). | `process.version` |
+| `--deep` | Deep inspection for monorepo projects (project mode only). | `false` |
+| `--ignore <value>` | Comma-separated package names to ignore. | — |
+| `--registry <value>` | Custom npm registry URL. | — |
+
+### Usage Examples
+
+```bash
+# Check current project against current Node version
+ndc compat
+
+# Check current project against Node 18
+ndc compat --node 18
+
+# Check specific package against Node 20
+ndc compat esbuild --node 20
+
+# Deep check monorepo against Node 18
+ndc compat --node 18 --deep
+
+# Check specific package with current Node version
+ndc compat lodash
+```
+
+## Two Modes
+
+### Project Mode (no packageName)
+
+When no package name is provided, the command checks all dependencies of the current project against the target Node version.
+
+- Collects dependencies from `package.json` (same logic as `current` command)
+- Resolves lockfile dependencies (npm/yarn/pnpm)
+- Supports `--deep` for monorepo projects (recursively finds all `package.json` files)
+- Supports `--ignore` to skip specific packages
+- Reports compatible/incompatible status and compatible version ranges for each dependency
+- Does NOT output deprecation information (checkDependencies still computes it, but renderCompatResult skips it)
+
+### Package Mode (with packageName)
+
+When a package name is provided, the command checks that specific package.
+
+- **Without `--node`**: Checks the package's current version compatibility with the current Node version (similar to `package` command but focused on compatibility).
+- **With `--node`**: Queries all versions of the package and reports the version range compatible with the target Node version.
+
+## Core Changes
+
+### 1. Parameterize `checkDependencies` in `check.ts`
+
+Currently, `currentNode` is a module-level constant derived from `process.version`. The `getPackageInfo` and `findCompatibleVersion` functions implicitly use it for compatibility checks.
+
+**Change**: Add an optional `targetNodeVersion` parameter to `checkDependencies` and propagate it to `getPackageInfo` and `findCompatibleVersion`. When not provided, fall back to `process.version` for backward compatibility.
+
+```typescript
+// Before
+const currentNode = coerce(process.version)!
+
+export async function checkDependencies(
+  dependencies: Record<string, VersionOrRange>,
+  config: CommonOption,
+  options?: {
+    dependencyTypes?: Record<string, 'production' | 'development'>
+    projectEnginesNode?: string
+    silent?: boolean
+  },
+): Promise<CheckResult>
+
+// After
+export async function checkDependencies(
+  dependencies: Record<string, VersionOrRange>,
+  config: CommonOption,
+  options?: {
+    dependencyTypes?: Record<string, 'production' | 'development'>
+    projectEnginesNode?: string
+    silent?: boolean
+    targetNodeVersion?: string
+  },
+): Promise<CheckResult>
+```
+
+Inside `getPackageInfo` and `findCompatibleVersion`, replace `currentNode` with:
+```typescript
+const effectiveNode = coerce(options?.targetNodeVersion) || coerce(process.version)!
+```
+
+### 2. New Type: `CompatOption`
+
+Add to `types.ts`:
+
+```typescript
+export interface CompatOption extends CommonOption {
+  packageName?: string
+  node?: string
+  deep: boolean
+  ignore: string
+}
+```
+
+### 3. New File: `src/io/compat.ts`
+
+Two internal functions:
+
+- `checkProjectCompat(options)`: Collects project dependencies (reusing logic from `current.ts`) and calls `checkDependencies` with `targetNodeVersion`.
+- `checkPackageCompat(options)`: Calls `checkDependencies` for the specified package with `targetNodeVersion`.
+
+Both delegate rendering to `renderCompatResult`.
+
+### 4. New Render Function: `renderCompatResult` in `render.ts`
+
+Dedicated render function for compatibility output. Follows the same output conventions as `renderCheckResult` (using `warn`, `log`, `ok`, `error` from `../utils/console` and `ansis` for coloring). Does NOT output deprecation information.
+
+**Project mode output** (follows existing renderCheckResult style):
+```
+ WARN  esbuild@0.20.0: 2024-01-15T12:00:00.000Z
+Required node: >=18
+Compatible version for Node v16.0.0: esbuild@0.19.12
+
+  OK    All dependencies are compatible with Node v20.11.0.
+
+📊 Node Version Summary:
+Minimum engines.node: >=18
+Target Node version: v16.0.0
+ WARN  Target Node version is below the minimum requirement!
+```
+
+**Package mode**:
+```
+ WARN  lodash@4.17.21: 2021-02-20T12:00:00.000Z
+Compatible with Node v20.11.0 (engines.node: >=6)
+```
+
+Or when incompatible:
+```
+ WARN  esbuild@0.20.0: 2024-01-15T12:00:00.000Z
+Required node: >=18
+Compatible version for Node v16.0.0: esbuild@0.19.12
+```
+
+### 5. CLI Registration in `cli.ts`
+
+```typescript
+program
+  .command('compat [packageName]')
+  .description('check Node.js version compatibility for project or package')
+  .addOption(new Option('--node <version>', 'target Node.js version'))
+  .addOption(new Option('--deep', 'deep inspection for monorepo projects'))
+  .addOption(new Option('--ignore <value>', 'ignore specific packages'))
+  .addOption(registryOption)
+  .action((packageName?: string, option: CompatOption) => {
+    checkCompat({ ...option, packageName })
+  })
+```
+
+### 6. MCP Tool: `check_compat`
+
+Add a new MCP tool to `src/mcp.ts`:
+
+```typescript
+server.tool(
+  'check_compat',
+  'Check Node.js version compatibility for a project or package. Reports which dependencies are compatible/incompatible with a target Node version based on engines.node.',
+  {
+    packageName: z.string().optional().describe('npm package name. If not provided, checks the current project.'),
+    nodeVersion: z.string().optional().describe('Target Node.js version (e.g. "18", "20.11.0"). Defaults to current Node version.'),
+    projectPath: z.string().optional().describe('Absolute path to project root (only used when packageName is not provided)'),
+    deep: z.boolean().optional().describe('Deep inspection for monorepo projects'),
+    ignore: z.string().optional().describe('Comma-separated package names to ignore'),
+    registry: z.string().optional().describe('Custom npm registry URL'),
+  },
+  async ({ packageName, nodeVersion, projectPath, deep, ignore, registry }) => {
+    // Validate inputs
+    // If packageName: call checkDependencies with targetNodeVersion
+    // If no packageName: collect project deps, call checkDependencies with targetNodeVersion
+    // Return JSON result
+  }
+)
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/types.ts` | Add `CompatOption` interface |
+| `src/check.ts` | Add `targetNodeVersion` parameter to `checkDependencies`, `getPackageInfo`, `findCompatibleVersion` |
+| `src/render.ts` | Add `renderCompatResult` function |
+| `src/cli.ts` | Register `compat` command |
+| `src/mcp.ts` | Add `check_compat` MCP tool |
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/io/compat.ts` | Compat command entry point (project mode + package mode) |
+
+## Backward Compatibility
+
+- `checkDependencies` defaults `targetNodeVersion` to `undefined`, falling back to `process.version`. All existing callers work without changes.
+- The `current`, `global`, `package`, and `node` commands are unaffected.
+- The MCP tools `check_package`, `check_current_project`, `check_global`, and `check_node` are unaffected.
+
+## Edge Cases
+
+- **Invalid Node version**: If `--node` receives an unparseable value (e.g. `--node abc`), coerce returns `null` and we fall back to `process.version` with a warning.
+- **Package with no `engines.node`**: Treated as compatible with any Node version (existing behavior).
+- **Package not found**: Return error message (existing behavior from `getPackageInfo`).
+- **No `package.json` in current directory**: Return error message (existing behavior from `getDependenciesOfPackageJson`).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,9 @@
 import antfu from '@antfu/eslint-config'
 
 export default antfu({
+  ignores: [
+    'docs/superpowers/**',
+  ],
   rules: {
     'test/no-import-node-test': 'off',
   },

--- a/src/check.ts
+++ b/src/check.ts
@@ -17,6 +17,7 @@ export async function checkDependencies(
     dependencyTypes?: Record<string, 'production' | 'development'>
     projectEnginesNode?: string
     silent?: boolean
+    targetNodeVersion?: string
   },
 ): Promise<CheckResult> {
   const packageList = Object.keys(dependencies)
@@ -29,7 +30,7 @@ export async function checkDependencies(
   for (const packageName of packageList) {
     if (!silent)
       startSpinner()
-    const result = await getPackageInfo(packageName, dependencies[packageName], config)
+    const result = await getPackageInfo(packageName, dependencies[packageName], config, options?.targetNodeVersion)
     if (options?.dependencyTypes && options.dependencyTypes[packageName]) {
       result.dependencyType = options.dependencyTypes[packageName]
     }
@@ -77,7 +78,8 @@ export async function checkDependencies(
   }
 }
 
-async function getPackageInfo(packageName: string, versionOrRange: VersionOrRange, config: CommonOption): Promise<PackageInfo> {
+async function getPackageInfo(packageName: string, versionOrRange: VersionOrRange, config: CommonOption, targetNodeVersion?: string): Promise<PackageInfo> {
+  const effectiveNode = coerce(targetNodeVersion) || currentNode
   let packageRes
   try {
     const registry = config.registry || globalConfig.registry || getRegistry()
@@ -129,11 +131,11 @@ async function getPackageInfo(packageName: string, versionOrRange: VersionOrRang
   let compatibleVersion: string | null = null
 
   if (requiredNode) {
-    if (satisfies(currentNode, requiredNode)) {
+    if (satisfies(effectiveNode, requiredNode)) {
       requiredNode = undefined
     }
     else {
-      compatibleVersion = findCompatibleVersion(packageRes, versionOrRange, currentNode)
+      compatibleVersion = findCompatibleVersion(packageRes, versionOrRange, effectiveNode)
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,9 @@
 import type { Command } from 'commander'
-import type { CommonOption, ConfigOption, CurrentOption, GlobalOption, PackageOption } from './types'
+import type { CommonOption, CompatOption, ConfigOption, CurrentOption, GlobalOption, PackageOption } from './types'
 import process from 'node:process'
 import { Option, program } from 'commander'
 import { version } from '../package.json'
+import checkCompat from './io/compat'
 import checkConfig from './io/config'
 import checkCurrent from './io/current'
 import checkGlobal from './io/global'
@@ -60,6 +61,21 @@ program
       ...option,
     }
     checkPackage(packageOption)
+  })
+
+program
+  .command('compat [packageName]')
+  .description('check Node.js version compatibility for project or package')
+  .addOption(new Option('--node <version>', 'target Node.js version'))
+  .addOption(new Option('--deep', 'deep inspection for monorepo projects'))
+  .addOption(new Option('--ignore <value>', 'ignore specific packages'))
+  .addOption(registryOption)
+  .action((packageName: string | undefined, option: any) => {
+    const compatOption: CompatOption = {
+      ...option,
+      packageName,
+    }
+    checkCompat(compatOption)
   })
 
 program

--- a/src/io/compat.ts
+++ b/src/io/compat.ts
@@ -1,44 +1,65 @@
-import type { CurrentOption, VersionOrRange } from '../types'
-import { readFileSync } from 'node:fs'
+import type { CompatOption, VersionOrRange } from '../types'
 import { join } from 'node:path'
 import process from 'node:process'
+import { coerce } from 'semver'
 import { checkDependencies } from '../check'
 import { isGitPackage, isLocalPackage, isURLPackage } from '../filter'
 import { getDependenciesOfLockfile } from '../packages/lockfiles'
 import { getDependenciesOfPackageJson } from '../packages/package_json'
-import { renderCheckResult } from '../render'
-import { error, log } from '../utils/console'
+import { renderCompatResult } from '../render'
+import { error, log, warn } from '../utils/console'
 import { findPackageJsonDirs } from '../utils/fs'
 
-export default async function checkCurrent(options: CurrentOption) {
+export default async function checkCompat(options: CompatOption) {
+  const targetNodeVersion = options.node || process.version
+  const effectiveNode = coerce(targetNodeVersion)
+  if (!effectiveNode) {
+    warn(`Invalid Node version: "${targetNodeVersion}", falling back to current Node version (${process.version})`)
+  }
+
+  if (options.packageName) {
+    await checkPackageCompat(options, targetNodeVersion)
+  }
+  else {
+    await checkProjectCompat(options, targetNodeVersion)
+  }
+}
+
+async function checkPackageCompat(options: CompatOption, targetNodeVersion: string) {
+  const { packageName, ...restOptions } = options
+  const checkOptions = { ...restOptions, failfast: false }
+
+  const result = await checkDependencies(
+    { [packageName!]: { range: undefined } },
+    checkOptions,
+    { targetNodeVersion },
+  )
+
+  renderCompatResult(result, {
+    targetNodeVersion,
+    packageName: packageName!,
+  })
+}
+
+async function checkProjectCompat(options: CompatOption, targetNodeVersion: string) {
   const currentPath = process.cwd()
   const pkgPaths = options.deep ? findPackageJsonDirs(currentPath) : [currentPath]
+
   for (const pkgPath of pkgPaths) {
     if (options.deep) {
       log(`> ${pkgPath}`)
     }
-    const result = await checkCurrentPackageJson(pkgPath, options)
+    await checkProjectPackageJson(pkgPath, options, targetNodeVersion)
     log()
-    if (options.failfast && result?.hasDeprecated) {
-      process.exit(1)
-    }
   }
 }
 
-async function checkCurrentPackageJson(pkgPath: string, options: CurrentOption) {
+async function checkProjectPackageJson(pkgPath: string, options: CompatOption, targetNodeVersion: string) {
   const packageJsonPath = join(pkgPath, 'package.json')
   const dependenciesOfPackageJson = getDependenciesOfPackageJson(packageJsonPath)
 
   if (!dependenciesOfPackageJson)
     return
-
-  let projectEnginesNode: string | undefined
-  try {
-    const packageJsonContent = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
-    projectEnginesNode = packageJsonContent.engines?.node
-  }
-  catch {
-  }
 
   try {
     const ignores = options.ignore?.split(',') || []
@@ -65,11 +86,11 @@ async function checkCurrentPackageJson(pkgPath: string, options: CurrentOption) 
     const dependenciesOfLockfile = await getDependenciesOfLockfile(npmDependencies)
     const dependencies = Object.assign(npmDependencies, dependenciesOfLockfile)
 
-    const result = await checkDependencies(dependencies, options, {
+    const result = await checkDependencies(dependencies, { registry: options.registry, failfast: false }, {
       dependencyTypes,
-      projectEnginesNode,
+      targetNodeVersion,
     })
-    renderCheckResult(result, { verbose: options.verbose })
+    renderCompatResult(result, { targetNodeVersion })
     return result
   }
   catch (e: any) {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -135,11 +135,12 @@ export async function startServer() {
         return errorResult(regResult.message)
 
       try {
-        const { existsSync, readdirSync, readFileSync, statSync } = await import('node:fs')
+        const { existsSync, readFileSync } = await import('node:fs')
         const { join, isAbsolute } = await import('node:path')
         const { isGitPackage, isLocalPackage, isURLPackage } = await import('./filter')
         const { getDependenciesOfLockfile } = await import('./packages/lockfiles')
         const { getDependenciesOfPackageJson } = await import('./packages/package_json')
+        const { findPackageJsonDirs } = await import('./utils/fs')
 
         const currentPath = projectPath || process.cwd()
         if (projectPath && !isAbsolute(projectPath))
@@ -148,33 +149,6 @@ export async function startServer() {
           return errorResult(`Project path does not exist: ${currentPath}`)
         if (!existsSync(join(currentPath, 'package.json')))
           return errorResult(`No package.json found in: ${currentPath}`)
-
-        function findPackageJsonDirs(dir: string, results: Array<string> = [], maxDepth: number = SECURITY.MAX_RECURSION_DEPTH, currentDepth: number = 0) {
-          if (currentDepth >= maxDepth)
-            return results
-          const pkgPath = join(dir, 'package.json')
-          if (existsSync(pkgPath))
-            results.push(dir)
-          let files
-          try {
-            files = readdirSync(dir)
-          }
-          catch {
-            return results
-          }
-          for (const file of files) {
-            if (file === 'node_modules')
-              continue
-            const dirPath = join(dir, file)
-            try {
-              const stat = statSync(dirPath)
-              if (stat.isDirectory())
-                findPackageJsonDirs(dirPath, results, maxDepth, currentDepth + 1)
-            }
-            catch {}
-          }
-          return results
-        }
 
         const pkgPaths = deep ? findPackageJsonDirs(currentPath, [], SECURITY.MAX_RECURSION_DEPTH, 0) : [currentPath]
         const allResults: CheckResult[] = []
@@ -329,6 +303,164 @@ export async function startServer() {
       }
       catch (e) {
         return errorResult(sanitizeError(e))
+      }
+    },
+  )
+
+  server.tool(
+    'check_compat',
+    'Check Node.js version compatibility for a project or package. Reports which dependencies are compatible/incompatible with a target Node version based on engines.node.',
+    {
+      packageName: z.string().optional().describe('npm package name. If not provided, checks the current project.'),
+      nodeVersion: z.string().optional().describe('Target Node.js version (e.g. "18", "20.11.0"). Defaults to current Node version.'),
+      projectPath: z.string().optional().describe('Absolute path to project root (only used when packageName is not provided)'),
+      deep: z.boolean().optional().describe('Deep inspection for monorepo projects'),
+      ignore: z.string().optional().describe('Comma-separated package names to ignore'),
+      registry: z.string().optional().describe('Custom npm registry URL'),
+    },
+    async ({ packageName, nodeVersion, projectPath, deep, ignore, registry }) => {
+      const regResult = validateRegistry(registry || '')
+      if (regResult instanceof Error)
+        return errorResult(regResult.message)
+
+      if (packageName) {
+        const nameResult = validatePackageName(packageName)
+        if (nameResult instanceof Error)
+          return errorResult(nameResult.message)
+
+        try {
+          const targetNodeVersion = nodeVersion || process.version
+          const result = await withTimeout(
+            checkDependencies(
+              { [nameResult]: { range: undefined } },
+              { registry: regResult, failfast: false },
+              { silent: true, targetNodeVersion },
+            ),
+            SECURITY.FETCH_TIMEOUT_MS,
+          )
+
+          const pkg = result.packages[0]
+          if (pkg?.error) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ error: sanitizeError(pkg.error) }, null, 2) }],
+            }
+          }
+
+          const compatResult = {
+            targetNodeVersion,
+            packages: result.packages.map(p => ({
+              name: p.name,
+              version: p.version,
+              compatible: !p.requiredNode,
+              nodeRequirement: p.nodeRequirement || null,
+              compatibleVersion: p.compatibleVersion || null,
+            })),
+            summary: {
+              total: result.summary.total,
+              incompatible: result.packages.filter(p => p.requiredNode).length,
+              errors: result.summary.errors,
+            },
+          }
+
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(compatResult, null, 2) }],
+          }
+        }
+        catch (e) {
+          return errorResult(sanitizeError(e))
+        }
+      }
+      else {
+        try {
+          const { existsSync } = await import('node:fs')
+          const { join, isAbsolute } = await import('node:path')
+          const { isGitPackage, isLocalPackage, isURLPackage } = await import('./filter')
+          const { getDependenciesOfLockfile } = await import('./packages/lockfiles')
+          const { getDependenciesOfPackageJson } = await import('./packages/package_json')
+          const { findPackageJsonDirs } = await import('./utils/fs')
+
+          const currentPath = projectPath || process.cwd()
+          if (projectPath && !isAbsolute(projectPath))
+            return errorResult('projectPath must be an absolute path')
+          if (!existsSync(currentPath))
+            return errorResult(`Project path does not exist: ${currentPath}`)
+          if (!existsSync(join(currentPath, 'package.json')))
+            return errorResult(`No package.json found in: ${currentPath}`)
+
+          const targetNodeVersion = nodeVersion || process.version
+          const pkgPaths = deep ? findPackageJsonDirs(currentPath, [], SECURITY.MAX_RECURSION_DEPTH, 0) : [currentPath]
+          const allDependencies: Record<string, VersionOrRange> = {}
+          const allDependencyTypes: Record<string, 'production' | 'development'> = {}
+
+          for (const pkgPath of pkgPaths) {
+            const packageJsonPath = join(pkgPath, 'package.json')
+            const dependenciesOfPackageJson = getDependenciesOfPackageJson(packageJsonPath)
+            if (!dependenciesOfPackageJson)
+              continue
+
+            const ignores = ignore?.split(',') || []
+            const npmDependencies: Record<string, VersionOrRange> = {}
+            const dependencyTypes: Record<string, 'production' | 'development'> = {}
+
+            for (const name in dependenciesOfPackageJson.dependencies) {
+              const versionInfo = dependenciesOfPackageJson.dependencies[name]
+              if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+                npmDependencies[name] = versionInfo
+                dependencyTypes[name] = 'production'
+              }
+            }
+
+            for (const name in dependenciesOfPackageJson.devDependencies) {
+              const versionInfo = dependenciesOfPackageJson.devDependencies[name]
+              if (!ignores.includes(name) && !isLocalPackage(versionInfo.range as string) && !isURLPackage(versionInfo.range as string) && !isGitPackage(versionInfo.range as string)) {
+                npmDependencies[name] = versionInfo
+                dependencyTypes[name] = 'development'
+              }
+            }
+
+            const dependenciesOfLockfile = await getDependenciesOfLockfile(npmDependencies)
+            Object.assign(allDependencies, npmDependencies, dependenciesOfLockfile)
+            Object.assign(allDependencyTypes, dependencyTypes)
+          }
+
+          const limitResult = withPackageLimit(allDependencies)
+          if (limitResult instanceof Error)
+            return errorResult(limitResult.message)
+
+          const config = { registry: regResult, failfast: false }
+          const result = await withTimeout(
+            checkDependencies(limitResult, config, {
+              dependencyTypes: allDependencyTypes,
+              targetNodeVersion,
+              silent: true,
+            }),
+            SECURITY.FETCH_TIMEOUT_MS,
+          )
+
+          const compatResult = {
+            targetNodeVersion,
+            packages: result.packages.map(p => ({
+              name: p.name,
+              version: p.version,
+              dependencyType: p.dependencyType || null,
+              compatible: !p.requiredNode,
+              nodeRequirement: p.nodeRequirement || null,
+              compatibleVersion: p.compatibleVersion || null,
+            })),
+            summary: {
+              total: result.summary.total,
+              incompatible: result.packages.filter(p => p.requiredNode).length,
+              errors: result.summary.errors,
+            },
+          }
+
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(compatResult, null, 2) }],
+          }
+        }
+        catch (e) {
+          return errorResult(sanitizeError(e))
+        }
       }
     },
   )

--- a/src/render.ts
+++ b/src/render.ts
@@ -132,3 +132,80 @@ export function renderNodeStatus(status: NodeStatus) {
     warn(`Your node version (${status.version}) can't be found in the release schedule. Please update 'npm-deprecated-check'.`)
   }
 }
+
+export function renderCompatResult(
+  result: CheckResult,
+  options?: {
+    targetNodeVersion?: string
+    packageName?: string
+  },
+) {
+  const { packages, hasErrors, nodeVersionSummary } = result
+  const targetNode = options?.targetNodeVersion || process.version
+  const targetNodeClean = coerce(targetNode)?.version || targetNode
+
+  if (options?.packageName) {
+    const pkg = packages[0]
+    if (pkg?.error) {
+      error(pkg.error)
+      return
+    }
+    warn(`${pkg!.name}@${pkg!.version}: ${pkg!.time}`)
+    if (pkg!.nodeRequirement) {
+      if (!pkg!.requiredNode) {
+        log(`${ansis.cyanBright('Compatible with Node ')}${ansis.magenta(targetNode)}${ansis.cyanBright(' (engines.node: ')}${ansis.magenta(pkg!.nodeRequirement)}${ansis.cyanBright(')')}`)
+      }
+      else {
+        log(`${ansis.magentaBright('Required node: ')}${pkg!.requiredNode}`)
+        if (pkg!.compatibleVersion) {
+          log(`${ansis.cyanBright(`Compatible version for Node ${targetNodeClean}: `)}${ansis.magenta(pkg!.compatibleVersion)}`)
+        }
+      }
+    }
+    else {
+      log(`${ansis.cyanBright('Compatible with Node ')}${ansis.magenta(targetNode)}${ansis.cyanBright(' (no engines.node constraint)')}`)
+    }
+    log()
+    return
+  }
+
+  for (const pkg of packages) {
+    if (pkg.error) {
+      error(pkg.error)
+      log()
+    }
+
+    if (pkg.requiredNode) {
+      warn(`${pkg.name}@${pkg.version}: ${pkg.time}`)
+      log(`${ansis.magentaBright('Required node: ')}${pkg.requiredNode}`)
+      if (pkg.compatibleVersion) {
+        log(`${ansis.cyanBright(`Compatible version for Node ${targetNodeClean}: `)}${ansis.magenta(pkg.compatibleVersion)}`)
+      }
+      log()
+    }
+  }
+
+  const incompatibleCount = packages.filter(p => p.requiredNode).length
+
+  if (!hasErrors && incompatibleCount === 0) {
+    ok(`All dependencies are compatible with Node ${targetNode}.`)
+  }
+
+  if (nodeVersionSummary) {
+    const { minimumRequired } = nodeVersionSummary
+    const productionMin = minimumRequired.production || minimumRequired.development
+
+    log()
+
+    if (productionMin) {
+      log(ansis.cyanBright('📊 Node Version Summary:'))
+      log(`Minimum engines.node: ${ansis.magenta(`>=${productionMin}`)}`)
+      log(`Target Node version: ${ansis.magenta(targetNode)}`)
+
+      const targetNodeSemver = coerce(targetNode)
+      if (targetNodeSemver && !satisfies(targetNodeSemver, `>=${productionMin}`)) {
+        warn(`Target Node version is below the minimum requirement!`)
+      }
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,13 @@ export interface PackageOption extends Omit<CommonOption, 'failfast'> {
   range?: string
 }
 
+export interface CompatOption extends CommonOption {
+  packageName?: string
+  node?: string
+  deep: boolean
+  ignore: string
+}
+
 export interface ConfigOption {
   get?: string
   set?: Array<string>

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,29 @@
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function findPackageJsonDirs(dir: string, results: Array<string> = [], maxDepth: number = Infinity, currentDepth: number = 0) {
+  if (currentDepth >= maxDepth)
+    return results
+  const pkgPath = join(dir, 'package.json')
+  if (existsSync(pkgPath))
+    results.push(dir)
+  let files
+  try {
+    files = readdirSync(dir)
+  }
+  catch {
+    return results
+  }
+  for (const file of files) {
+    if (file === 'node_modules')
+      continue
+    const dirPath = join(dir, file)
+    try {
+      const stat = statSync(dirPath)
+      if (stat.isDirectory())
+        findPackageJsonDirs(dirPath, results, maxDepth, currentDepth + 1)
+    }
+    catch {}
+  }
+  return results
+}

--- a/test/compat.spec.js
+++ b/test/compat.spec.js
@@ -1,0 +1,102 @@
+/* eslint-disable no-control-regex */
+import assert from 'node:assert/strict'
+import { exec, execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const cli = path.resolve(__dirname, '../dist/cli.mjs')
+
+const managers = ['npm', 'yarn', 'pnpm']
+const cases = ['deprecated', 'normal']
+const playgroundDir = path.join(__dirname, 'playground')
+
+const requiredNodeRegex = /^\u001B\[95mRequired node:/gm
+const nodeVersionSummaryRegex = /📊 Node Version Summary:/
+const compatibleRegex = /compatible with Node/i
+
+async function check(manager, t) {
+  const normalDir = path.join(playgroundDir, manager, 'normal')
+  const deprecatedDir = path.join(playgroundDir, manager, 'deprecated')
+
+  await t.test(`check ${manager} compat: normal project shows all compatible`, (_t, done) => {
+    exec(`cd ${normalDir} && node ${cli} compat`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+      assert.doesNotMatch(stdout, requiredNodeRegex, 'Not expected "Required node" in normal project.')
+      done()
+    })
+  })
+
+  await t.test(`check ${manager} compat: deprecated project may show required node`, (_t, done) => {
+    exec(`cd ${deprecatedDir} && node ${cli} compat`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+      assert.ok(nodeVersionSummaryRegex.test(stdout) || compatibleRegex.test(stdout) || requiredNodeRegex.test(stdout), 'Expected compat output.')
+      done()
+    })
+  })
+
+  await t.test(`check ${manager} compat with --node 14: shows incompatibility for eslint`, (_t, done) => {
+    exec(`cd ${deprecatedDir} && node ${cli} compat --node 14`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+      assert.ok(requiredNodeRegex.test(stdout) || /Node.*14/.test(stdout), 'Expected "Required node" or Node 14 in output.')
+      done()
+    })
+  })
+
+  await t.test(`check ${manager} compat: ignore specific packages`, (_t, done) => {
+    exec(`cd ${deprecatedDir} && node ${cli} compat --ignore request,tslint`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+      assert.doesNotMatch(stdout, /request@/, 'Not expected "request@" in output when ignored.')
+      assert.doesNotMatch(stdout, /tslint@/, 'Not expected "tslint@" in output when ignored.')
+      done()
+    })
+  })
+}
+
+test('compat tests', async (t) => {
+  try {
+    for (const manager of managers) {
+      for (const caseName of cases) {
+        const caseDir = path.join(playgroundDir, manager, caseName)
+        fs.mkdirSync(caseDir, { recursive: true })
+
+        const srcFile = path.join(__dirname, 'examples', `${caseName}.json`)
+        const destFile = path.join(caseDir, 'package.json')
+        fs.copyFileSync(srcFile, destFile)
+        execSync(`${manager} install --quiet`, { cwd: caseDir })
+      }
+
+      await check(manager, t)
+    }
+
+    await t.test('deep inspection: checks all subdirectories', (_t, done) => {
+      exec(`cd ${playgroundDir} && node ${cli} compat --deep`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+        assert.ok(nodeVersionSummaryRegex.test(stdout) || compatibleRegex.test(stdout) || requiredNodeRegex.test(stdout), 'Expected compat output in deep mode.')
+        done()
+      })
+    })
+
+    await t.test('shows Node Version Summary when dependencies have engines.node', (_t, done) => {
+      const deprecatedDir = path.join(playgroundDir, 'npm', 'deprecated')
+      exec(`cd ${deprecatedDir} && node ${cli} compat`, { timeout: 160000 }, (_error, stdout, _stderr) => {
+        if (nodeVersionSummaryRegex.test(stdout)) {
+          assert.ok(/Minimum engines\.node:/.test(stdout), 'Expected minimum engines.node message.')
+        }
+        else {
+          assert.ok(compatibleRegex.test(stdout) || requiredNodeRegex.test(stdout), 'Expected compat output.')
+        }
+        done()
+      })
+    })
+
+    await t.test('package mode: check specific package compatibility', (_t, done) => {
+      exec(`node ${cli} compat eslint --node 18`, { timeout: 30000 }, (_error, stdout, stderr) => {
+        const output = stdout + stderr
+        assert.ok(/eslint@/.test(output) || /Node 18/.test(output) || /Compatible with Node/.test(output), 'Expected eslint compatibility output.')
+        done()
+      })
+    })
+  }
+  finally {
+    fs.rmSync(playgroundDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Add a new `compat` command that checks Node.js version compatibility for a project or package based on `engines.node`. This helps users determine whether their dependencies are compatible when upgrading or downgrading to a target Node version.

## CLI Usage

```bash
# Check current project against current Node version
ndc compat

# Check current project against Node 18
ndc compat --node 18

# Check specific package against Node 20
ndc compat esbuild --node 20

# Deep check monorepo against Node 18
ndc compat --node 18 --deep

# Ignore specific packages
ndc compat --ignore request,tslint
```

## Options

| Option | Description | Default |
|--------|-------------|---------|
| `[packageName]` | Optional package name. If omitted, checks the current project | — |
| `--node <version>` | Target Node.js version (e.g. `18`, `20.11.0`) | Current Node version |
| `--deep` | Deep inspection for monorepo projects (project mode only) | `false` |
| `--ignore <value>` | Comma-separated package names to ignore | — |
| `--registry <value>` | Custom npm registry URL | — |

## Two Modes

### Project Mode (no packageName)

- Collects dependencies from `package.json` and lockfile
- Supports `--deep` for monorepo projects
- Reports compatible/incompatible status and compatible version ranges
- Does NOT output deprecation information (focused on Node compatibility only)

### Package Mode (with packageName)

- **Without `--node`**: Checks the package's current version compatibility with the current Node version
- **With `--node`**: Queries all versions of the package and reports the version range compatible with the target Node version

## MCP Tool

New `check_compat` tool added for AI agents:

```json
{ "packageName": "esbuild", "nodeVersion": "18", "deep": false, "ignore": "", "registry": "" }
```